### PR TITLE
Disable token usage in CI workflow for Paras

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ParaS-Ecosystem/ParaS-Compiler
-          token: ${{ secrets.PARAS_REPO_TOKEN }}
+          ##token: ${{ secrets.PARAS_REPO_TOKEN }}
           path: ParaS-Compiler
 
       - name: Build and install ParaS Compiler


### PR DESCRIPTION
Commented out the token line in the CI workflow to prevent exposure of sensitive information.